### PR TITLE
Wrong parameter in function doCloneObject

### DIFF
--- a/classes/class.ilObjTestRepositoryObject.php
+++ b/classes/class.ilObjTestRepositoryObject.php
@@ -87,7 +87,7 @@ class ilObjTestRepositoryObject extends ilObjectPlugin implements ilLPStatusPlug
 	/**
 	 * Do Cloning
 	 */
-	function doCloneObject($a_target_id,$a_copy_id,$new_obj)
+	function doCloneObject($new_obj, $a_target_id, $a_copy_id = null)
 	{
 		global $ilDB;
 


### PR DESCRIPTION
in parent class ilObject2 $new_obj is first